### PR TITLE
Use "createTime" instead of "createDate"

### DIFF
--- a/bbb-mon/frontend/main.js
+++ b/bbb-mon/frontend/main.js
@@ -17,10 +17,7 @@ function api_meetings() {
         data.forEach(function(element, i) {
             let mods = element.moderators.join(" | ");
 
-            // Ugly hack to make JS accept CET datetime
-            // Will break with daylight savings and/or different timezones.
-            let creationDateRaw = element.creation.replace("CET", "");
-            let creation = new Date(Date.parse(creationDateRaw));
+            let creation = new Date(parseFloat(element.creation));
 
             let originContext = "";
             if (element.metadata['origin-context']) {

--- a/bbb-mon/views.py
+++ b/bbb-mon/views.py
@@ -59,7 +59,7 @@ def get_meetings():
         m = {
             "name": meeting['meetingName'],
             "id": meeting['meetingID'],
-            "creation": meeting['createDate'],
+            "creation": meeting['createTime'],
             "noUsers": meeting['participantCount'],
             "moderators": moderators,
             "metadata": {


### PR DESCRIPTION
I was getting "Invalid date" as creation date in the interface, because
the Javascript didn't seem to like the format of the dates returned by
BBB.

Switch to using the "createTime" attribute which is a standard Unix
timestamp.  It avoids the need to parse dates in Javascript.

Tested with BBB 2.2